### PR TITLE
Make ReactGateway server renderable by removing dependency on document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ export default class MyComponent extends React.Component {
 
 ## Props
 
-| Name | Type | Description |
-| --- | --- | --- | --- |
-| `to` | `HTMLElement` | Specify where in the DOM to go to. (Default: `document.body`) |
-| `className` | `String` | Add a className to the generated DOM node. |
+| Name | Type | Description | Required
+| --- | --- | --- | --- | --- |
+| `to` | `HTMLElement` | Specify where in the DOM to go to. (Default: `document.body`) | yes |
+| `className` | `String` | Add a className to the generated DOM node. | no |
+
+`to` prop is required to keep `react-gateway` renderable on server. You can wrap ReactGateway by your own component 
+and supply `document.body` there.

--- a/index.js
+++ b/index.js
@@ -15,12 +15,6 @@ module.exports = React.createClass({
     children: React.PropTypes.element.isRequired
   },
 
-  getDefaultProps: function() {
-    return {
-      to: document.body
-    };
-  },
-
   componentDidMount: function() {
     this.gatewayNode = document.createElement('div');
     if (this.props.className) this.gatewayNode.className = this.props.className;


### PR DESCRIPTION
This is probably a breaking change so please advise.