### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dialog"
   ],
   "author": "James Kyle <me@thejameskyle.com>",
+  "repository": "https://github.com/cloudflare/react-gateway",
   "license": "BSD-3-Clause",
   "dependencies": {
     "react": "^0.14.2"


### PR DESCRIPTION
I always seem to end up the npm page for packages, so when I find one without a repo link it makes me sad :sob: 

Hence, my PRs that just add repo links :wink: 