### PR TITLE
Allow the tagName to be a custom component

### DIFF
--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -10,8 +10,7 @@ export default class GatewayDest extends React.Component {
     name: React.PropTypes.string.isRequired,
     tagName: React.PropTypes.oneOfType([
       React.PropTypes.string,
-      React.PropTypes.func,
-      React.PropTypes.instanceOf(React.Component)
+      React.PropTypes.func
     ])
   };
 

--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -8,7 +8,11 @@ export default class GatewayDest extends React.Component {
 
   static propTypes = {
     name: React.PropTypes.string.isRequired,
-    tagName: React.PropTypes.string
+    tagName: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.func,
+      React.PropTypes.instanceOf(React.Component)
+    ])
   };
 
   static defaultProps = {

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,21 @@ describe('Gateway', function() {
     );
   });
 
+  it('should be able to customize the GatewayDest with custom components', function() {
+    class Child extends React.Component {
+      render() {
+	return <h1 id='test'>{ this.props.children }</h1>;
+      }
+    }
+    assertEqual(
+      <GatewayProvider>
+        <GatewayDest tagName={Child} id="striped" name="foo"/>
+      </GatewayProvider>,
+      // should equal
+      <Child/>
+    );
+  });
+
   it('should render into the correct GatewayDest', function() {
     assertEqual(
       <GatewayProvider>


### PR DESCRIPTION
It already worked as expected but was producing PropType
warnings in development mode.