### PR TITLE
React 15 prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "repository": "https://github.com/cloudflare/react-gateway",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "react": "^0.14.2"
+    "react": "^0.14.2 || ^15.0.0-rc.2"
   },
   "devDependencies": {
     "babel-cli": "^6.1.1",
@@ -48,7 +48,7 @@
     "karma-tape-reporter": "^1.0.3",
     "minimist": "^1.2.0",
     "mocha": "^2.3.3",
-    "react-addons-test-utils": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react-addons-test-utils": "^0.14.2 || ^15.0.0-rc.2",
+    "react-dom": "^0.14.2 || ^15.0.0-rc.2"
   }
 }

--- a/src/Gateway.js
+++ b/src/Gateway.js
@@ -33,7 +33,6 @@ export default class Gateway extends React.Component {
   }
 
   renderIntoGatewayNode(props) {
-    delete props.ref;
     this.gatewayRegistry.addChild(this.props.into, props.children);
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,18 @@ import {
   GatewayProvider
 } from '../src/index.js';
 
+// React v15 uses commment nodes for empty components instead of `<noscript />`
+// so in those cases we can skip rendering children
+const emptyComponent = (function emptyComponent() {
+  const [major, minor, patch] = React.version.split('.').map(Number);
+
+  if (major >= 15) {
+    return null;
+  }
+
+  return <noscript />;
+})();
+
 function render(jsx) {
   return ReactDOMServer.renderToStaticMarkup(jsx);
 }
@@ -32,7 +44,7 @@ describe('Gateway', function() {
       // should equal
       <div>
         <section>
-          <noscript/>
+          {emptyComponent}
         </section>
         <div>Hello World</div>
       </div>
@@ -76,8 +88,8 @@ describe('Gateway', function() {
       </GatewayProvider>,
       // should equal
       <div>
-        <noscript/>
-        <noscript/>
+        {emptyComponent}
+        {emptyComponent}
         <div>Two</div>
         <div>One</div>
       </div>
@@ -137,7 +149,7 @@ describe('Gateway', function() {
       <Application/>,
       // should equal
       <div>
-        <noscript/>
+        {emptyComponent}
         <div>
           <span>Hello from context</span>
         </div>


### PR DESCRIPTION
Adds in a couple of small changes to prepare for React 15 support.  

- No deleting of `ref` in `props`.  
- Helper for properly rendering an empty component depending on the loaded React version