### PR TITLE
Examples should use `component` instead of `tagName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export default class Application extends React.Component {
             </Gateway>
             <div className="item">Item 3</div>
           </div>
-          <GatewayDest name="one" tagName="section" className="hello"/>
+          <GatewayDest name="one" component="section" className="hello"/>
           <GatewayDest name="two"/>
         </div>
       </GatewayProvider>

--- a/example/Application.js
+++ b/example/Application.js
@@ -32,7 +32,7 @@ class Application extends React.Component {
             <div className="item">Item 3</div>
           </div>
         )}
-        <GatewayDest name="one" tagName="section" className="hello"/>
+        <GatewayDest name="one" component="section" className="hello"/>
         <GatewayDest name="two"/>
       </div>
     );


### PR DESCRIPTION
Modifies the README and example file to use the non-deprecated `component` prop in place of `tagName`