### PR TITLE
Support multiple children, expose gateway registry

### DIFF
--- a/src/Gateway.js
+++ b/src/Gateway.js
@@ -24,12 +24,12 @@ export default class Gateway extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    this.gatewayRegistry.clearChild(this.props.into);
+    this.gatewayRegistry.clearChild(this.props.into, this.props.children);
     this.renderIntoGatewayNode(props);
   }
 
   componentWillUnmount() {
-    this.gatewayRegistry.removeChild(this.props.into);
+    this.gatewayRegistry.removeChild(this.props.into, this.props.children);
   }
 
   renderIntoGatewayNode(props) {

--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -36,6 +36,6 @@ export default class GatewayDest extends React.Component {
   render() {
     const { component, tagName, ...attrs } = this.props;
     delete attrs.name;
-    return React.createElement(component || tagName || 'div', attrs, this.state.child);
+    return React.createElement(component || tagName || 'div', attrs, this.state.children);
   }
 }

--- a/src/GatewayRegistry.js
+++ b/src/GatewayRegistry.js
@@ -10,7 +10,7 @@ export default class GatewayRegistry {
     }
 
     this._containers[name].setState({
-      child: this._children[name]
+      children: this._children[name]
     });
   }
 
@@ -24,22 +24,17 @@ export default class GatewayRegistry {
   }
 
   addChild(name, child) {
-    if (this._children[name]) {
-      console.warn(
-        'Only a single Gateway can be rendered at a time into a GatewayDest.' +
-        `You rendered multiple into "${name}"`
-      );
-    }
-    this._children[name] = child;
+    this._children[name] = this._children[name] || [];
+    this._children[name].push(child);
     this._renderContainer(name);
   }
 
-  clearChild(name) {
-    this._children[name] = null;
+  clearChild(name, child) {
+    this._children[name] = this._children[name].filter(item => item !== child);
   }
 
-  removeChild(name) {
-    this.clearChild(name);
+  removeChild(name, child) {
+    this.clearChild(name, child);
     this._renderContainer(name);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export Gateway from './Gateway';
 export GatewayDest from './GatewayDest';
 export GatewayProvider from './GatewayProvider';
+export GatewayRegistry from './GatewayRegistry';


### PR DESCRIPTION
I know this functionality was previous removed, but doing so causes an issue with cf-ui/cf-component-modal, which now fails if you define more than one modal at at a time.

Supporting multiple children seems like the best solution to me, but what were the reasons for its previous removal, and are they still relevant?

I also want to expose the GatewayRegistry to enable integration with our backbone codebase. Since we can't have a single component wrapping all the react code, I want to create a registry provider component to wrap all our react-views which uses a single shared registry.