### PR TITLE
Child Order Consistency

### DIFF
--- a/src/Gateway.js
+++ b/src/Gateway.js
@@ -20,20 +20,21 @@ export default class Gateway extends React.Component {
   }
 
   componentWillMount() {
+    this.id = this.gatewayRegistry.register(this.props.into, this.props.children);
     this.renderIntoGatewayNode(this.props);
   }
 
   componentWillReceiveProps(props) {
-    this.gatewayRegistry.clearChild(this.props.into, this.props.children);
+    this.gatewayRegistry.clearChild(this.props.into, this.id);
     this.renderIntoGatewayNode(props);
   }
 
   componentWillUnmount() {
-    this.gatewayRegistry.removeChild(this.props.into, this.props.children);
+    this.gatewayRegistry.unregister(this.props.into, this.id);
   }
 
   renderIntoGatewayNode(props) {
-    this.gatewayRegistry.addChild(this.props.into, props.children);
+    this.gatewayRegistry.addChild(this.props.into, this.id, props.children);
   }
 
   render() {

--- a/src/GatewayRegistry.js
+++ b/src/GatewayRegistry.js
@@ -2,6 +2,9 @@ export default class GatewayRegistry {
   constructor() {
     this._containers = {};
     this._children = {};
+
+    // Unique key for children of a gateway
+    this._currentId = 0;
   }
 
   _renderContainer(name) {
@@ -10,7 +13,7 @@ export default class GatewayRegistry {
     }
 
     this._containers[name].setState({
-      children: Object.keys(this._children[name]).sort((a, b) => a < b).map(id => this._children[name][id])
+      children: Object.keys(this._children[name]).sort().map(id => this._children[name][id])
     });
   }
 
@@ -35,8 +38,10 @@ export default class GatewayRegistry {
   register(name, child) {
     this._children[name] = this._children[name] || {};
 
-    const gatewayId = '' + Object.keys(this._children[name]).length;
+    const gatewayId = `${name}_${this._currentId}`;
     this._children[name][gatewayId] = child;
+    this._currentId += 1;
+
     return gatewayId;
   }
 

--- a/src/GatewayRegistry.js
+++ b/src/GatewayRegistry.js
@@ -5,12 +5,12 @@ export default class GatewayRegistry {
   }
 
   _renderContainer(name) {
-    if (!this._containers[name]) {
+    if (!this._containers[name] || !this._children[name]) {
       return;
     }
 
     this._containers[name].setState({
-      children: this._children[name]
+      children: Object.keys(this._children[name]).sort((a, b) => a < b).map(id => this._children[name][id])
     });
   }
 
@@ -23,18 +23,25 @@ export default class GatewayRegistry {
     this._containers[name] = null;
   }
 
-  addChild(name, child) {
-    this._children[name] = this._children[name] || [];
-    this._children[name].push(child);
+  addChild(name, gatewayId, child) {
+    this._children[name][gatewayId] = child;
     this._renderContainer(name);
   }
 
-  clearChild(name, child) {
-    this._children[name] = this._children[name].filter(item => item !== child);
+  clearChild(name, gatewayId) {
+    delete this._children[name][gatewayId];
   }
 
-  removeChild(name, child) {
-    this.clearChild(name, child);
+  register(name, child) {
+    this._children[name] = this._children[name] || {};
+
+    const gatewayId = '' + Object.keys(this._children[name]).length;
+    this._children[name][gatewayId] = child;
+    return gatewayId;
+  }
+
+  unregister(name, gatewayId) {
+    this.clearChild(name, gatewayId);
     this._renderContainer(name);
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,8 @@ import ReactDOMServer from 'react-dom/server';
 import {
   Gateway,
   GatewayDest,
-  GatewayProvider
+  GatewayProvider,
+  GatewayRegistry
 } from '../src/index.js';
 
 function render(jsx) {
@@ -79,6 +80,40 @@ describe('Gateway', function() {
     );
   });
 
+  it('should render multiple children into a single GatewayDest', function() {
+    assertEqual(
+      <GatewayProvider>
+        <div>
+          <section>
+            <Gateway into="foo">
+              <div>One</div>
+            </Gateway>
+            <div>
+              <Gateway into="foo">
+                <div>Two</div>
+              </Gateway>
+            </div>
+            <Gateway into="foo">
+              <div>Three</div>
+            </Gateway>
+          </section>
+          <GatewayDest name="foo"/>
+        </div>
+      </GatewayProvider>,
+      // should equal
+      <div>
+        <section>
+          <div />
+        </section>
+        <div>
+          <div>One</div>
+          <div>Two</div>
+          <div>Three</div>
+        </div>
+      </div>
+    );
+  });
+
   it('should pass context', function() {
     class Child extends React.Component {
       static contextTypes = {
@@ -137,5 +172,21 @@ describe('Gateway', function() {
         </div>
       </div>
     );
+  });
+});
+
+describe('GatewayRegistry', function() {
+  describe('register', function () {
+    it('should return a gateway id', function () {
+      const gatewayRegistry = new GatewayRegistry();
+      expect(gatewayRegistry.register('test', <span />)).to.equal('test_0');
+    });
+
+    it('should increment intrernal ids', function () {
+      const gatewayRegistry = new GatewayRegistry();
+      gatewayRegistry.register('test', <span />);
+      gatewayRegistry.register('test', <span />);
+      expect(gatewayRegistry._currentId).to.equal(2);
+    });
   });
 });


### PR DESCRIPTION
When rendering multiple`Gateway`s into the same `GatewayDestination` the order of the child components isn't enforced, meaning that whenever the `Gateway` receives props there's a chance that the component tree will change.

We ran into this issue when rendering multiple `cf-ui` `cf-component-modal`s on the same page, as they each render into the same `GatewayDestination`. Whenever props changed, the order of the components would switch, causing `ReactCSSTransitionGroup` flickering and `ref` losses.