### PR TITLE
Get PropTypes from 'prop-types' instead of 'react' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "repository": "https://github.com/cloudflare/react-gateway",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "prop-types": "^15.5.0",
     "react": "^0.14.2 || ^15.0.0-0",
     "react-prop-types": "^0.4.0"
   },

--- a/src/Gateway.js
+++ b/src/Gateway.js
@@ -1,16 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import GatewayRegistry from './GatewayRegistry';
 
 export default class Gateway extends React.Component {
   static contextTypes = {
-    gatewayRegistry: React.PropTypes.instanceOf(GatewayRegistry).isRequired
+    gatewayRegistry: PropTypes.instanceOf(GatewayRegistry).isRequired
   };
 
   static propTypes = {
-    into: React.PropTypes.string.isRequired,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.element,
-      React.PropTypes.string
+    into: PropTypes.string.isRequired,
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string
     ])
   };
 

--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -1,18 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import GatewayRegistry from './GatewayRegistry';
 import {deprecated} from 'react-prop-types';
 
 export default class GatewayDest extends React.Component {
   static contextTypes = {
-    gatewayRegistry: React.PropTypes.instanceOf(GatewayRegistry).isRequired
+    gatewayRegistry: PropTypes.instanceOf(GatewayRegistry).isRequired
   };
 
   static propTypes = {
-    name: React.PropTypes.string.isRequired,
-    tagName: deprecated(React.PropTypes.string, 'Use "component" instead.'),
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func
+    name: PropTypes.string.isRequired,
+    tagName: deprecated(PropTypes.string, 'Use "component" instead.'),
+    component: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func
     ])
   };
 

--- a/src/GatewayProvider.js
+++ b/src/GatewayProvider.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import GatewayRegistry from './GatewayRegistry';
 
 export default class GatewayProvider extends React.Component {
   static childContextTypes = {
-    gatewayRegistry: React.PropTypes.instanceOf(GatewayRegistry).isRequired
+    gatewayRegistry: PropTypes.instanceOf(GatewayRegistry).isRequired
   };
 
   getChildContext() {
@@ -13,7 +14,7 @@ export default class GatewayProvider extends React.Component {
   }
 
   static propTypes = {
-    children: React.PropTypes.element,
+    children: PropTypes.element,
   };
 
   constructor(props, context) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOMServer from 'react-dom/server';
 import {
   Gateway,
@@ -117,7 +118,7 @@ describe('Gateway', function() {
   it('should pass context', function() {
     class Child extends React.Component {
       static contextTypes = {
-        textContent: React.PropTypes.string.isRequired
+        textContent: PropTypes.string.isRequired
       };
 
       constructor(props, context) {
@@ -136,7 +137,7 @@ describe('Gateway', function() {
 
     class Parent extends React.Component {
       static childContextTypes = {
-        textContent: React.PropTypes.string.isRequired
+        textContent: PropTypes.string.isRequired
       };
 
       getChildContext() {


### PR DESCRIPTION
Fixes react 15.5.x deprecation warning