### PR TITLE
Fix lifecycle ordering bug removing recently added container

### DIFF
--- a/src/GatewayRegistry.js
+++ b/src/GatewayRegistry.js
@@ -22,8 +22,10 @@ export default class GatewayRegistry {
     this._renderContainer(name);
   }
 
-  removeContainer(name) {
-    this._containers[name] = null;
+  removeContainer(name, container) {
+    if (this._containers[name] === container) {
+      this._containers[name] = null;
+    }
   }
 
   addChild(name, gatewayId, child) {


### PR DESCRIPTION
In React 16, when swapping in components, componentWillMount now fires on the new components before componentWillUnmount fires on the old ones. This means that unmounting a GatewayDest and mounting one of the same name will call addContainer and removeContainer in the wrong order. As a result, the GatewayDest no longer receives updates from rerendered Gateways.

This PR makes it so that removeContainer checks what container it is removing and noops if it would remove the wrong container.