### PR TITLE
Enable default children on gateway destination

### DIFF
--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -37,6 +37,6 @@ export default class GatewayDest extends React.Component {
   render() {
     const { component, tagName, ...attrs } = this.props;
     delete attrs.name;
-    return React.createElement(component || tagName || 'div', attrs, this.state.children);
+    return React.createElement(component || tagName || 'div', attrs, this.state.children || this.props.children);
   }
 }


### PR DESCRIPTION
This is very useful for me as I use `Gateway` for my navigation and it enables me to change navigation items from every every route or have the default value displayes