### PR TITLE
Fix props usage in renderIntoGatewayNode

### DIFF
--- a/src/Gateway.js
+++ b/src/Gateway.js
@@ -35,7 +35,7 @@ export default class Gateway extends React.Component {
   }
 
   renderIntoGatewayNode(props) {
-    this.gatewayRegistry.addChild(this.props.into, this.id, props.children);
+    this.gatewayRegistry.addChild(props.into, this.id, props.children);
   }
 
   render() {


### PR DESCRIPTION
renderIntoGatewayNode used to invoke this.props instead of props.

When called by componentWillUnmount, it would cause addChild to be called with the old into