### PR TITLE
GatewayDest: allow noWrapper mode

### DIFF
--- a/src/GatewayDest.js
+++ b/src/GatewayDest.js
@@ -9,6 +9,7 @@ export default class GatewayDest extends React.Component {
   };
 
   static propTypes = {
+    noWrapper: PropTypes.bool,
     name: PropTypes.string.isRequired,
     tagName: deprecated(PropTypes.string, 'Use "component" instead.'),
     component: PropTypes.oneOfType([
@@ -35,8 +36,11 @@ export default class GatewayDest extends React.Component {
   }
 
   render() {
-    const { component, tagName, ...attrs } = this.props;
+    const { component, tagName, noWrapper, ...attrs } = this.props;
     delete attrs.name;
+    if ( noWrapper ) {
+      return this.state.children;
+    }
     return React.createElement(component || tagName || 'div', attrs, this.state.children);
   }
 }


### PR DESCRIPTION
GatewayDest should be able to render components in place without the need to add a wrapper element.

My usecase for this is my GatewayDest is inside a container with `align-items: space-between`. Having an empty wrapper View here messes up my layout. (It's for a dynamic RN dev toolbar menu)

Also, I think not having a wrapper could be a nice default, and make react-gateway work out of the box with RN. If the user wants to wrap his dest he could still do that in userland.

But that would be a breaking change and require minimum React version to work.